### PR TITLE
Articles: Add Markdown support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem 'webpacker', '~> 5.0'
 gem 'turbolinks', '~> 5'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder', '~> 2.7'
+gem 'redcarpet'
 # Use Redis adapter to run Action Cable in production
 # gem 'redis', '~> 4.0'
 # Use Active Model has_secure_password

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -156,6 +156,7 @@ GEM
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     rcodetools (0.8.5.0)
+    redcarpet (3.5.1)
     regexp_parser (2.1.1)
     rexml (3.2.5)
     rubocop (1.15.0)
@@ -237,6 +238,7 @@ DEPENDENCIES
   rack-mini-profiler (~> 2.0)
   rails (~> 6.1.3, >= 6.1.3.2)
   rcodetools
+  redcarpet
   rubocop
   sass-rails (>= 6)
   selenium-webdriver

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -15,8 +15,11 @@ class ArticlesController < ApplicationController
 
   def create
     @article = Article.new(article_params)
+    markdown = Redcarpet::Markdown.new(Redcarpet::Render::HTML,
+                                       :autolink => true, :space_after_headers => true)
 
     if @article.save
+      @article.update(body: markdown.render(article_params["body"]), title: article_params["title"])
       redirect_to @article
     else
       render :new
@@ -30,7 +33,10 @@ class ArticlesController < ApplicationController
   def update
     @article = Article.find(params[:id])
 
-    if @article.update(article_params)
+    markdown = Redcarpet::Markdown.new(Redcarpet::Render::HTML,
+                                       :autolink => true, :space_after_headers => true)
+
+    if @article.update(body: markdown.render(article_params["body"]), title: article_params["title"])
       redirect_to @article
     else
       render :edit

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -1,6 +1,6 @@
 <h1><%= @article.title %></h1>
 
-<p><%= @article.body %></p>
+<div class="article-content"><%== @article.body %></div>
 
 <ul>
   <li><%= link_to "Edit", edit_article_path(@article) %></li>


### PR DESCRIPTION
There should be markdown support so you can create bold text, italic text, code blocks, ...

Fixes #7﻿
